### PR TITLE
build-tc: Dont double quote --defines

### DIFF
--- a/build-tc.sh
+++ b/build-tc.sh
@@ -45,7 +45,7 @@ msg "Building LLVM..."
 tg_post_msg "<code>Building LLVM</code>"
 ./build-llvm.py \
 	--clang-vendor "Azure" \
-	--defines "LLVM_PARALLEL_COMPILE_JOBS=$(nproc) LLVM_PARALLEL_LINK_JOBS=$(nproc) CMAKE_C_FLAGS=-O3 CMAKE_CXX_FLAGS=-O3" \
+	--defines LLVM_PARALLEL_COMPILE_JOBS=$(nproc) LLVM_PARALLEL_LINK_JOBS=$(nproc) CMAKE_C_FLAGS=-O3 CMAKE_CXX_FLAGS=-O3 \
 	--incremental \
 	--lto thin \
 	--projects "clang;lld;polly;compiler-rt" \


### PR DESCRIPTION
double quoting it would treat it as a single cmake value, thus not getting passed properly while invoking ninja.

when i passed --show-build-commands to build-llvm.py, i got an output something like this:
`$ cmake -G Ninja -Wno-dev -DCLANG_ENABLE_ARCMT=OFF -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DCLANG_PLUGIN_SUPPORT=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR= -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DCMAKE_AR=/usr/lib/llvm-15/bin/llvm-ar -DCMAKE_C_COMPILER=/usr/lib/llvm-15/bin/clang -DCMAKE_CXX_COMPILER=/usr/lib/llvm-15/bin/clang++ -DLLVM_USE_LINKER=/usr/lib/llvm-15/bin/ld.lld -DCMAKE_RANLIB=/usr/lib/llvm-15/bin/llvm-ranlib -DLLVM_ENABLE_PROJECTS=clang;lld;compiler-rt -DCOMPILER_RT_BUILD_LIBFUZZER=OFF -DCOMPILER_RT_BUILD_CRT=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DLLVM_TARGETS_TO_BUILD=host -DLLVM_CCACHE_BUILD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_UTILS=OFF -DLLVM_ENABLE_BACKTRACES=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_INCLUDE_TESTS=OFF -DCLANG_VENDOR=Azure -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_PARALLEL_COMPILE_JOBS=8 LLVM_PARALLEL_LINK_JOBS=8 CMAKE_C_FLAGS=-O3 CMAKE_CXX_FLAGS=-O3 /home/dakkshesh/Desktop/tc-build-1/llvm-project/llvm`

as seen above `LLVM_PARALLEL_LINK_JOBS=8 CMAKE_C_FLAGS=-O3 CMAKE_CXX_FLAGS=-O3` are missing `-D` in front of them, thus they never get used.

but after removing the double quotes, i got a output like this:
`$ cmake -G Ninja -Wno-dev -DCLANG_ENABLE_ARCMT=OFF -DCLANG_ENABLE_STATIC_ANALYZER=OFF -DCLANG_PLUGIN_SUPPORT=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR= -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DCMAKE_AR=/usr/lib/llvm-15/bin/llvm-ar -DCMAKE_C_COMPILER=/usr/lib/llvm-15/bin/clang -DCMAKE_CXX_COMPILER=/usr/lib/llvm-15/bin/clang++ -DLLVM_USE_LINKER=/usr/lib/llvm-15/bin/ld.lld -DCMAKE_RANLIB=/usr/lib/llvm-15/bin/llvm-ranlib -DLLVM_ENABLE_PROJECTS=clang;lld;compiler-rt -DCOMPILER_RT_BUILD_LIBFUZZER=OFF -DCOMPILER_RT_BUILD_CRT=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_BUILD_SANITIZERS=OFF -DLLVM_TARGETS_TO_BUILD=host -DLLVM_CCACHE_BUILD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_UTILS=OFF -DLLVM_ENABLE_BACKTRACES=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_INCLUDE_TESTS=OFF -DCLANG_VENDOR=Azure -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_PARALLEL_COMPILE_JOBS=8 -DLLVM_PARALLEL_LINK_JOBS=8 -DCMAKE_C_FLAGS=-O3 -DCMAKE_CXX_FLAGS=-O3 /home/dakkshesh/Desktop/tc-build-1/llvm-project/llvm`

the flags get passed properly now :D